### PR TITLE
Throw TypeError when trying to serialize native built-in functions

### DIFF
--- a/lib/serialize.js
+++ b/lib/serialize.js
@@ -2,7 +2,8 @@
 
 module.exports = serialize;
 
-var PLACE_HOLDER_REGEX = /"@__(FUNCTION|REGEXP)_(\d+)__@"/g;
+var IS_NATIVE_CODE_REGEX = /\{\s*\[native code\]\s*\}/g,
+    PLACE_HOLDER_REGEX   = /"@__(FUNCTION|REGEXP)_(\d+)__@"/g;
 
 function serialize(obj) {
     var functions = [],
@@ -34,11 +35,17 @@ function serialize(obj) {
     // string with their string representations. If the original value can not
     // be found, then `undefined` is used.
     return str.replace(PLACE_HOLDER_REGEX, function (match, type, index) {
-        switch (type) {
-        case 'FUNCTION':
-            return functions[index].toString();
-        case 'REGEXP':
+        if (type === 'REGEXP') {
             return regexps[index].toString();
         }
+
+        var fn           = functions[index],
+            serializedFn = fn.toString();
+
+        if (IS_NATIVE_CODE_REGEX.test(serializedFn)) {
+            throw new TypeError('Serializing native function: ' + fn.name);
+        }
+
+        return serializedFn;
     });
 }

--- a/test/serialize.js
+++ b/test/serialize.js
@@ -97,6 +97,13 @@ describe('serialize', function () {
             expect(fn).to.be.a('function');
             expect(fn()).to.equal(true);
         });
+
+        it('should throw a TypeError when serializing native built-ins', function () {
+            var err;
+            expect(Number.toString()).to.equal('function Number() { [native code] }');
+            try { serialize(Number); } catch (e) { err = e; }
+            expect(err).to.be.an.instanceOf(TypeError);
+        });
     });
 
     describe('regexps', function () {


### PR DESCRIPTION
This changes the serialization process of functions to throw when a native built-in function is trying to be serialized.
