### PR TITLE
Fix test script to run on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,6 @@
     },
 
     "scripts": {
-        "test": "./node_modules/istanbul/lib/cli.js cover -- ./node_modules/.bin/_mocha test/*.js --reporter spec"
+        "test": "istanbul cover -- ./node_modules/mocha/bin/_mocha test/ --reporter spec"
     }
 }


### PR DESCRIPTION
Windows had some trouble getting to the Istanbul CLI and finding the right Mocha script. This variation of the test script should work on all platforms.
