### PR TITLE
Keep namespaces near data to avoid shadowing namespaces

### DIFF
--- a/lib/exposed.js
+++ b/lib/exposed.js
@@ -71,7 +71,6 @@ Exposed.prototype.add = function (namespace, value, options) {
 
 Exposed.prototype.toString = function () {
     var rendered   = {},
-        namespaces = '',
         data       = '',
         serialized = this.__serialized__;
 
@@ -94,7 +93,7 @@ Exposed.prototype.toString = function () {
             nsPart += '.' + parts.shift();
 
             if (!rendered[nsPart]) {
-                namespaces += nsPart  + ' || (' + nsPart + ' = {});\n';
+                data += nsPart  + ' || (' + nsPart + ' = {});\n';
                 rendered[nsPart] = true;
             }
         }
@@ -108,8 +107,6 @@ Exposed.prototype.toString = function () {
 
     return (
         '\n(function (root) {\n' +
-            '// -- Namespaces --\n' +
-            namespaces +
             '\n// -- Data --\n' +
             data +
         '}(this));\n');

--- a/test/unit/exposed.js
+++ b/test/unit/exposed.js
@@ -354,5 +354,15 @@ describe('Exposed', function () {
             expect(window.foo.bar).to.equal('BAR');
             expect(window.foo.baz).to.equal('baz');
         });
+
+        it('should not shadow namespaces', function () {
+            exposed.add('foo', {});
+            exposed.add('foo.bar.baz', 'baz');
+
+            evalExposed(exposed);
+            expect(window.foo).to.be.an('object');
+            expect(window.foo.bar).to.be.an('object');
+            expect(window.foo.bar.baz).to.equal('baz');
+        });
     });
 });


### PR DESCRIPTION
This patch removes the separation of namespaces from their data, which fixes yahoo/express-state#23.
